### PR TITLE
renames bearer_token to bearer to align with other systems. Also adds…

### DIFF
--- a/pkg/pull/pull.go
+++ b/pkg/pull/pull.go
@@ -117,7 +117,7 @@ func InvalidateFederationDueToFailure(fed int) bool {
 // for authentication
 func (p *Pull) GenerateHeaders(req *http.Request) {
 	switch strings.ToUpper(p.Method) {
-	case "BEARER_TOKEN":
+	case "BEARER":
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", p.AccessToken))
 	case "API_KEY":
 		req.Header.Add("apikey", p.AccessToken)
@@ -331,6 +331,7 @@ func Run() {
 				"label":             dataset.Summary.Title,
 				"short_description": dataset.Summary.Abstract,
 				"dataset":           string(jsonString),
+				"create_origin":     "FMA",
 			}
 
 			jsonPayload, _ := json.Marshal(body)

--- a/pkg/routes/test.go
+++ b/pkg/routes/test.go
@@ -66,7 +66,7 @@ func TestFederationHandler(c *gin.Context) {
 		"status":  status,
 		"message": ret,
 		"title":   title,
-		"errors":  err.Error(),
+		"errors":  nil,
 	})
 	return
 }

--- a/tests/pull_test.go
+++ b/tests/pull_test.go
@@ -66,7 +66,7 @@ func testGetFederations(t *testing.T) []pkg.Federation {
 	jsonString := `[
 		{
 			"id": 1,
-			"auth_type": "bearer_token",
+			"auth_type": "bearer",
 			"auth_secret_key": "projects/987760029877/secrets/dev-gateway-mfs-aridhia/versions/latest",
 			"endpoint_baseurl": "https://fair.preview.aridhia.io/api/syndication/hdruk",
 			"endpoint_datasets": "/datasets?assigned=true",
@@ -145,7 +145,7 @@ func TestGenerateHeaders(t *testing.T) {
 		false,
 	)
 
-	assert.EqualValues(t, "bearer_token", p.Method)
+	assert.EqualValues(t, "bearer", p.Method)
 	assert.EqualValues(t, "TEST-BEARER-TOKEN", p.AccessToken)
 }
 


### PR DESCRIPTION
… in the recent create_origin for datasets